### PR TITLE
Fix ENOENT on windows

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 # github
 .github
+
+# test
+spec

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { resolve } = require('path');
 const { spawn } = require('child_process');
+const os = require('os');
 
 function working() {
     let P = ['\\', '|', '/', '-'];
@@ -24,7 +25,8 @@ function stopWorking(workingInterval) {
 
 (function() {
     try {
-        const package = require(resolve(process.cwd(), './package.json'));
+        const cwd = process.cwd();
+        const package = require(resolve(cwd, './package.json'));
         if (Object.prototype.hasOwnProperty.call(package, 'peerDependencies')) {
             let packages = Object.keys(package.peerDependencies).map(function(key) {
                 return `${key}@"${package.peerDependencies[key]}"`
@@ -34,15 +36,21 @@ function stopWorking(workingInterval) {
                 return process.exit();
             }
             const args = [
-                'install'
+                'i'
             ];
             args.push.apply(args, packages);
             args.push.apply(args, [
-                '--no-save'
+                '--no-save',
             ]);
             process.stdout.write(`npm ${args.join(' ')}\n`);
             const workingInterval = working();
-            const npm = spawn('npm', args, );
+            // change command to npm.cmd on windows
+            const cmd = os.type() === 'Windows_NT' ? 'npm.cmd' : 'npm';
+            const windowsVerbatimArguments = true;
+            const npm = spawn(cmd, args, {
+                cwd, // set current directory
+                windowsVerbatimArguments // do not escape arguments (windows only)
+            });
             npm.stdout.on('data', (data) => {
                 stopWorking(workingInterval);
                 process.stdout.write(data);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/peers",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Install peer dependencies utility",
   "bin": {
     "add-peers": "bin/add-peers"

--- a/spec/app1/package.json
+++ b/spec/app1/package.json
@@ -1,0 +1,9 @@
+{
+    "license": "MIT",
+    "peerDependencies": {
+        "@angular/common": "^11||^12||^13||^14||^15",
+        "@angular/core": "^11||^12||^13||^14||^15"
+    },
+    "dependencies": {
+    }
+}


### PR DESCRIPTION
This PR fixes `ENOENT` error on windows while executing `npx @themost/peers`